### PR TITLE
Make $image_path overridable

### DIFF
--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -77,7 +77,7 @@ $performance_font: 'Helvetica', 'Arial', sans-serif !default;
 @import "functions";
 
 /* ==========  IMAGES  ========== */
-$image_path: '/images';
+$image_path: '/images' !default;
 
 /* ==========  Color & Themes  ========== */
 


### PR DESCRIPTION
I f this variable is not marked as !default one cannot override this when the mdl framework is used only partially as sass import in case one wants to use different image  path settings.